### PR TITLE
Refactored ui items and `components_to_dict`

### DIFF
--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -271,43 +271,6 @@ class ActionRow:
         return self._underlying.to_dict()
 
 
-def components_to_dict(components: Components) -> List[ActionRowPayload]:
-    if not isinstance(components, Sequence):
-        components = [components]
-
-    action_rows = []
-    auto_row = ActionRow()
-
-    for component in components:
-        if isinstance(component, WrappedComponent):
-            try:
-                auto_row.append_item(component)
-            except ValueError:
-                action_rows.append(auto_row.to_component_dict())
-                auto_row = ActionRow(component)
-        else:
-            if auto_row.width > 0:
-                action_rows.append(auto_row.to_component_dict())
-                auto_row = ActionRow()
-
-            if isinstance(component, ActionRow):
-                action_rows.append(component.to_component_dict())
-
-            elif isinstance(component, list):
-                action_rows.append(ActionRow(*component).to_component_dict())
-
-            else:
-                raise ValueError(
-                    "components must be a WrappedComponent, a list of ActionRow "
-                    "or a list of WrappedComponent"
-                )
-
-    if auto_row.width > 0:
-        action_rows.append(auto_row.to_component_dict())
-
-    return action_rows
-
-
 def components_to_rows(components: Components) -> List[ActionRow]:
     if not isinstance(components, Sequence):
         components = [components]
@@ -343,3 +306,7 @@ def components_to_rows(components: Components) -> List[ActionRow]:
         action_rows.append(auto_row)
 
     return action_rows
+
+
+def components_to_dict(components: Components) -> List[ActionRowPayload]:
+    return [row.to_component_dict() for row in components_to_rows(components)]

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -56,28 +56,28 @@ class ActionRow:
 
     Parameters
     ----------
-    *items: :class:`WrappedComponent`
-        The items of this action row.
+    *components: :class:`WrappedComponent`
+        The components of this action row.
     """
 
-    def __init__(self, *items: WrappedComponent):
+    def __init__(self, *components: WrappedComponent):
         self.width: int = 0
-        components = []
+        raw_components = []
         # Validate the components
-        for item in items:
-            if not isinstance(item, WrappedComponent):
+        for component in components:
+            if not isinstance(component, WrappedComponent):
                 raise ValueError("ActionRow must contain only WrappedComponent instances")
 
-            self.width += item.width
+            self.width += component.width
 
             if self.width > 5:
-                raise ValueError("Too many items in one row.")
+                raise ValueError("Too many components in one row.")
 
-            components.append(item._underlying)  # type: ignore
+            raw_components.append(component._underlying)
 
         self._underlying = ActionRowComponent._raw_construct(
             type=ComponentType.action_row,
-            children=components,
+            children=raw_components,
         )
 
     def __repr__(self) -> str:
@@ -97,12 +97,12 @@ class ActionRow:
         return self._underlying.type
 
     def append_item(self, item: WrappedComponent) -> None:
-        """Appends an item to the action row.
+        """Appends a component to the action row.
 
         Parameters
         ----------
         item: :class:`WrappedComponent`
-            The item to append to the action row.
+            The component to append to the action row.
 
         Raises
         ------
@@ -110,7 +110,7 @@ class ActionRow:
             The width of the action row exceeds 5.
         """
         if self.width + item.width > 5:
-            raise ValueError("Too many items in this row, can not append a new one.")
+            raise ValueError("Too many components in this row, can not append a new one.")
 
         self.width += item.width
         self._underlying.children.append(item._underlying)  # type: ignore
@@ -127,7 +127,7 @@ class ActionRow:
     ):
         """Adds a button to the action row.
 
-        To append a pre-existing :class:`disnake.ui.Button` use the
+        To append a pre-existing :class:`~disnake.ui.Button` use the
         :meth:`append_item` method instead.
 
         Parameters
@@ -174,7 +174,7 @@ class ActionRow:
     ):
         """Adds a select menu to the action row.
 
-        To append a pre-existing :class:`disnake.ui.Select` use the
+        To append a pre-existing :class:`~disnake.ui.Select` use the
         :meth:`append_item` method instead.
 
         Parameters
@@ -225,7 +225,7 @@ class ActionRow:
     ):
         """Adds an input text to the action row.
 
-        To append a pre-existing :class:`disnake.ui.InputText` use the
+        To append a pre-existing :class:`~disnake.ui.InputText` use the
         :meth:`append_item` method instead.
 
         .. versionadded:: 2.4

--- a/disnake/ui/action_row.py
+++ b/disnake/ui/action_row.py
@@ -62,7 +62,7 @@ class ActionRow:
 
     def __init__(self, *components: WrappedComponent):
         self.width: int = 0
-        raw_components = []
+        raw_components: List[NestedComponent] = []
         # Validate the components
         for component in components:
             if not isinstance(component, WrappedComponent):

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -85,7 +85,7 @@ class Button(Item[V]):
         "emoji",
         "row",
     )
-
+    # We have to set this to MISSING in order to overwrite the abstract property from WrappedComponent
     _underlying: ButtonComponent = MISSING
 
     def __init__(

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -117,7 +117,7 @@ class Button(Item[V]):
                     f"expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}"
                 )
 
-        self._underlying = ButtonComponent._raw_construct(
+        self._underlying: ButtonComponent = ButtonComponent._raw_construct(
             type=ComponentType.button,
             custom_id=custom_id,
             url=url,
@@ -211,13 +211,6 @@ class Button(Item[V]):
             emoji=button.emoji,
             row=None,
         )
-
-    @property
-    def type(self) -> ComponentType:
-        return self._underlying.type
-
-    def to_component_dict(self):
-        return self._underlying.to_dict()
 
     def is_dispatchable(self) -> bool:
         return self.custom_id is not None

--- a/disnake/ui/button.py
+++ b/disnake/ui/button.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Callable, Optional, Tuple, Type, TypeVar, Unio
 from ..components import Button as ButtonComponent
 from ..enums import ButtonStyle, ComponentType
 from ..partial_emoji import PartialEmoji, _EmojiTag
+from ..utils import MISSING
 from .item import DecoratedItem, Item
 
 __all__ = (
@@ -85,6 +86,8 @@ class Button(Item[V]):
         "row",
     )
 
+    _underlying: ButtonComponent = MISSING
+
     def __init__(
         self,
         *,
@@ -117,7 +120,7 @@ class Button(Item[V]):
                     f"expected emoji to be str, Emoji, or PartialEmoji not {emoji.__class__}"
                 )
 
-        self._underlying: ButtonComponent = ButtonComponent._raw_construct(
+        self._underlying = ButtonComponent._raw_construct(
             type=ComponentType.button,
             custom_id=custom_id,
             url=url,
@@ -127,6 +130,10 @@ class Button(Item[V]):
             emoji=emoji,
         )
         self.row = row
+
+    @property
+    def width(self) -> int:
+        return 1
 
     @property
     def style(self) -> ButtonStyle:

--- a/disnake/ui/input_text.py
+++ b/disnake/ui/input_text.py
@@ -70,7 +70,7 @@ class InputText(WrappedComponent):
         "min_length",
         "max_length",
     )
-
+    # We have to set this to MISSING in order to overwrite the abstract property from WrappedComponent
     _underlying: InputTextComponent = MISSING
 
     def __init__(

--- a/disnake/ui/input_text.py
+++ b/disnake/ui/input_text.py
@@ -23,14 +23,12 @@ DEALINGS IN THE SOFTWARE.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import Optional, Tuple
 
 from ..components import InputText as InputTextComponent
 from ..enums import ComponentType, InputTextStyle
+from ..utils import MISSING
 from .item import WrappedComponent
-
-if TYPE_CHECKING:
-    from ..types.components import InputText as InputTextPayload
 
 
 __all__ = ("InputText",)
@@ -74,6 +72,8 @@ class InputText(WrappedComponent):
         "max_length",
     )
 
+    _underlying: InputTextComponent = MISSING
+
     def __init__(
         self,
         *,
@@ -86,7 +86,7 @@ class InputText(WrappedComponent):
         min_length: int = 0,
         max_length: Optional[int] = None,
     ) -> None:
-        self._underlying: InputTextComponent = InputTextComponent._raw_construct(
+        self._underlying = InputTextComponent._raw_construct(
             type=ComponentType.input_text,
             style=style,
             label=label,

--- a/disnake/ui/input_text.py
+++ b/disnake/ui/input_text.py
@@ -30,7 +30,6 @@ from ..enums import ComponentType, InputTextStyle
 from ..utils import MISSING
 from .item import WrappedComponent
 
-
 __all__ = ("InputText",)
 
 

--- a/disnake/ui/input_text.py
+++ b/disnake/ui/input_text.py
@@ -86,7 +86,7 @@ class InputText(WrappedComponent):
         min_length: int = 0,
         max_length: Optional[int] = None,
     ) -> None:
-        self._underlying = InputTextComponent._raw_construct(
+        self._underlying: InputTextComponent = InputTextComponent._raw_construct(
             type=ComponentType.input_text,
             style=style,
             label=label,
@@ -101,11 +101,6 @@ class InputText(WrappedComponent):
     @property
     def width(self) -> int:
         return 5
-
-    @property
-    def type(self) -> ComponentType:
-        """:class:`.ComponentType`: The type of the input text. This is always :attr:`.ComponentType.input_text`."""
-        return self._underlying.type
 
     @property
     def style(self) -> InputTextStyle:
@@ -178,6 +173,3 @@ class InputText(WrappedComponent):
     @max_length.setter
     def max_length(self, value: Optional[int]) -> None:
         self._underlying.max_length = value
-
-    def to_component_dict(self) -> InputTextPayload:
-        return self._underlying.to_dict()

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -98,6 +98,7 @@ class WrappedComponent(ABC):
 
 class Item(WrappedComponent, Generic[V]):
     """Represents the base UI item that all UI items inherit from.
+
     This class adds more functionality on top of the :class:`WrappedComponent` base class.
     This functionality mostly relates to :class:`disnake.ui.View`.
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
+from abc import ABC, abstractproperty
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -54,7 +55,7 @@ if TYPE_CHECKING:
     ItemCallbackType = Callable[[Any, I, MessageInteraction], Coroutine[Any, Any, Any]]
 
 
-class WrappedComponent:
+class WrappedComponent(ABC):
     """Represents the base UI component that all UI components inherit from.
 
     The current UI components supported are:
@@ -68,24 +69,34 @@ class WrappedComponent:
 
     __repr_attributes__: Tuple[str, ...]
 
-    def to_component_dict(self) -> Dict[str, Any]:
-        raise NotImplementedError
+    @abstractproperty
+    def _underlying(self) -> Component:
+        ...
 
-    @property
-    def type(self) -> ComponentType:
-        raise NotImplementedError
+    @_underlying.setter
+    def _underlying(self, value: Component):
+        ...
+
+    @abstractproperty
+    def width(self) -> int:
+        ...
 
     def __repr__(self) -> str:
         attrs = " ".join(f"{key}={getattr(self, key)!r}" for key in self.__repr_attributes__)
         return f"<{self.__class__.__name__} {attrs}>"
 
     @property
-    def width(self) -> int:
-        return 1
+    def type(self) -> ComponentType:
+        return self._underlying.type
+
+    def to_component_dict(self) -> Dict[str, Any]:
+        return self._underlying.to_dict()
 
 
 class Item(WrappedComponent, Generic[V]):
-    """Represents the base UI item that all UI components inherit from.
+    """Represents the base UI item that all UI items inherit from.
+    This class adds more functionality on top of the :class:`WrappedComponent` base class.
+    This functionality mostly relates to :class:`disnake.ui.View`.
 
     The current UI items supported are:
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 
 from __future__ import annotations
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -69,7 +69,8 @@ class WrappedComponent(ABC):
 
     __repr_attributes__: Tuple[str, ...]
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _underlying(self) -> Component:
         ...
 
@@ -77,7 +78,8 @@ class WrappedComponent(ABC):
     def _underlying(self, value: Component):
         ...
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def width(self) -> int:
         ...
 

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -75,10 +75,6 @@ class WrappedComponent(ABC):
     def _underlying(self) -> NestedComponent:
         ...
 
-    @_underlying.setter
-    def _underlying(self, value: NestedComponent):
-        ...
-
     @property
     @abstractmethod
     def width(self) -> int:

--- a/disnake/ui/item.py
+++ b/disnake/ui/item.py
@@ -47,9 +47,10 @@ I = TypeVar("I", bound="Item")
 V = TypeVar("V", bound="View", covariant=True)
 
 if TYPE_CHECKING:
-    from ..components import Component
+    from ..components import NestedComponent
     from ..enums import ComponentType
     from ..interactions import MessageInteraction
+    from ..types.components import Component as ComponentPayload
     from .view import View
 
     ItemCallbackType = Callable[[Any, I, MessageInteraction], Coroutine[Any, Any, Any]]
@@ -71,11 +72,11 @@ class WrappedComponent(ABC):
 
     @property
     @abstractmethod
-    def _underlying(self) -> Component:
+    def _underlying(self) -> NestedComponent:
         ...
 
     @_underlying.setter
-    def _underlying(self, value: Component):
+    def _underlying(self, value: NestedComponent):
         ...
 
     @property
@@ -91,7 +92,7 @@ class WrappedComponent(ABC):
     def type(self) -> ComponentType:
         return self._underlying.type
 
-    def to_component_dict(self) -> Dict[str, Any]:
+    def to_component_dict(self) -> ComponentPayload:
         return self._underlying.to_dict()
 
 
@@ -122,14 +123,14 @@ class Item(WrappedComponent, Generic[V]):
         # only called upon edit and we're mainly interested during initial creation time.
         self._provided_custom_id: bool = False
 
-    def refresh_component(self, component: Component) -> None:
+    def refresh_component(self, component: NestedComponent) -> None:
         return None
 
     def refresh_state(self, interaction: MessageInteraction) -> None:
         return None
 
     @classmethod
-    def from_component(cls: Type[I], component: Component) -> I:
+    def from_component(cls: Type[I], component: NestedComponent) -> I:
         return cls()
 
     def is_dispatchable(self) -> bool:

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -109,7 +109,7 @@ class Select(Item[V]):
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         options = [] if options is MISSING else options
-        self._underlying = SelectMenu._raw_construct(
+        self._underlying: SelectMenu = SelectMenu._raw_construct(
             custom_id=custom_id,
             type=ComponentType.select,
             placeholder=placeholder,
@@ -260,9 +260,6 @@ class Select(Item[V]):
     def width(self) -> int:
         return 5
 
-    def to_component_dict(self) -> SelectMenuPayload:
-        return self._underlying.to_dict()
-
     def refresh_component(self, component: SelectMenu) -> None:
         self._underlying = component
 
@@ -280,10 +277,6 @@ class Select(Item[V]):
             disabled=component.disabled,
             row=None,
         )
-
-    @property
-    def type(self) -> ComponentType:
-        return self._underlying.type
 
     def is_dispatchable(self) -> bool:
         return True

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -91,7 +91,7 @@ class Select(Item[V]):
         "options",
         "disabled",
     )
-
+    # We have to set this to MISSING in order to overwrite the abstract property from WrappedComponent
     _underlying: SelectMenu = MISSING
 
     def __init__(

--- a/disnake/ui/select.py
+++ b/disnake/ui/select.py
@@ -43,7 +43,6 @@ __all__ = (
 if TYPE_CHECKING:
     from ..emoji import Emoji
     from ..interactions import MessageInteraction
-    from ..types.components import SelectMenu as SelectMenuPayload
     from .item import ItemCallbackType
     from .view import View
 
@@ -93,6 +92,8 @@ class Select(Item[V]):
         "disabled",
     )
 
+    _underlying: SelectMenu = MISSING
+
     def __init__(
         self,
         *,
@@ -109,7 +110,7 @@ class Select(Item[V]):
         self._provided_custom_id = custom_id is not MISSING
         custom_id = os.urandom(16).hex() if custom_id is MISSING else custom_id
         options = [] if options is MISSING else options
-        self._underlying: SelectMenu = SelectMenu._raw_construct(
+        self._underlying = SelectMenu._raw_construct(
             custom_id=custom_id,
             type=ComponentType.select,
             placeholder=placeholder,

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -36,6 +36,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    cast,
     ClassVar,
     Dict,
     Iterator,
@@ -49,6 +50,7 @@ from ..components import (
     ActionRow as ActionRowComponent,
     Button as ButtonComponent,
     Component,
+    NestedComponent,
     SelectMenu as SelectComponent,
     _component_factory,
 )
@@ -66,15 +68,15 @@ if TYPE_CHECKING:
     from .item import ItemCallbackType
 
 
-def _walk_all_components(components: List[Component]) -> Iterator[Component]:
+def _walk_all_components(components: List[Component]) -> Iterator[NestedComponent]:
     for item in components:
         if isinstance(item, ActionRowComponent):
             yield from item.children
         else:
-            yield item
+            yield cast(NestedComponent, item)
 
 
-def _component_to_item(component: Component) -> Item:
+def _component_to_item(component: NestedComponent) -> Item:
     if isinstance(component, ButtonComponent):
         from .button import Button
 

--- a/disnake/ui/view.py
+++ b/disnake/ui/view.py
@@ -36,7 +36,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    cast,
     ClassVar,
     Dict,
     Iterator,
@@ -44,6 +43,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    cast,
 )
 
 from ..components import (


### PR DESCRIPTION
## Summary

Should've called this branch `refactor/modals` but eh.

- `WrappedComponent` is now an `ABC`
- `WrappedComponent.width` is now an abstract property
- `WrappedComponent._underlying` is now an abstract property
- `.to_component_dict()` and `.type` are now implemented in `WrappedComponent` and removed from the subclasses.
